### PR TITLE
Added termcolor to list of dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(
         'pyyaml',
         'pyelftools',
         'python-magic',
+        'termcolor',
         'tracer @ git+https://github.com/angr/tracer.git',
    ],
 )


### PR DESCRIPTION
The dependency `termcolor` was missing from setup.py and has been added.