### PR TITLE
Move inserted data and code segments to higher addresses

### DIFF
--- a/patcherex/backends/detourbackends/_elf.py
+++ b/patcherex/backends/detourbackends/_elf.py
@@ -53,8 +53,8 @@ class DetourBackendElf(Backend):
         self.name_map = RejectingDict()
 
         # where to put the segments in memory
-        self.added_code_segment = 0x0600000
-        self.added_data_segment = 0x0700000
+        self.added_code_segment = 0x06000000
+        self.added_data_segment = 0x07000000
         current_hdr = self.structs.Elf_Ehdr.parse(self.ncontent)
         self.single_segment_header_size = current_hdr["e_phentsize"]
         assert self.single_segment_header_size >= self.structs.Elf_Phdr.sizeof()

--- a/patcherex/backends/detourbackends/arm.py
+++ b/patcherex/backends/detourbackends/arm.py
@@ -27,6 +27,9 @@ class DetourBackendArm(DetourBackendElf):
             raise NotImplementedError()
         super().__init__(filename, base_address=base_address, try_reuse_unused_space=try_reuse_unused_space, 
             replace_note_segment=replace_note_segment, try_without_cfg=try_without_cfg)
+        # Override code and data segment address since it fails for ARM
+        self.added_code_segment = 0x0600000
+        self.added_data_segment = 0x0700000
 
     def get_block_containing_inst(self, inst_addr):
         index = bisect.bisect_right(self.ordered_nodes, inst_addr) - 1


### PR DESCRIPTION
This PR moves the location of the data and code segments to higher addresses so as to not overwrite valid code in some cases (eg: statically linked binaries). Since some ARM 32-bit test cases seem to break, current values are used instead of the new ones only for ARM 32-bit.